### PR TITLE
refactor: router edit

### DIFF
--- a/src/component/MainComponent.jsx
+++ b/src/component/MainComponent.jsx
@@ -1,4 +1,4 @@
-import BasicLayout from "../layout/BasicLayout.jsx";
+
 
 function MainComponent() {
     return (

--- a/src/component/qna/QNAReadComponent.jsx
+++ b/src/component/qna/QNAReadComponent.jsx
@@ -1,0 +1,11 @@
+
+
+function QnaReadComponent() {
+    return (
+        <div>
+            <div>QNA Read Component</div>
+        </div>
+    );
+}
+
+export default QnaReadComponent;

--- a/src/page/MainPage.jsx
+++ b/src/page/MainPage.jsx
@@ -1,10 +1,12 @@
-import MainComponent from "../component/MainComponent.jsx";
+import BasicLayout from "../layout/BasicLayout.jsx";
+
 
 function MainPage() {
     return (
         <div>
+            <BasicLayout>
             <div>Main Page</div>
-            <MainComponent></MainComponent>
+            </BasicLayout>
         </div>
     );
 }

--- a/src/page/QNAIndex.jsx
+++ b/src/page/QNAIndex.jsx
@@ -1,14 +1,15 @@
+
 import BasicLayout from "../layout/BasicLayout.jsx";
 import {Outlet} from "react-router-dom";
 
-function AdminIndex() {
+function QnaIndex() {
     return (
         <BasicLayout>
-            <div className="flex-1 p-10 bg-green-50">
-                <Outlet />
-            </div>
+        <div>
+            <Outlet/>
+        </div>
         </BasicLayout>
     );
 }
 
-export default AdminIndex;
+export default QnaIndex;

--- a/src/page/QNAReadPage.jsx
+++ b/src/page/QNAReadPage.jsx
@@ -1,0 +1,13 @@
+import QNAReadComponent from "../component/qna/QNAReadComponent.jsx";
+
+
+function QnaReadPage() {
+    return (
+        <div>
+            <div>QNA Read Page</div>
+            <QNAReadComponent/>
+        </div>
+    );
+}
+
+export default QnaReadPage;

--- a/src/router/MainRouter.jsx
+++ b/src/router/MainRouter.jsx
@@ -1,20 +1,13 @@
 import {createBrowserRouter} from "react-router-dom";
-import AdminIndex from "../page/AdminIndex.jsx";
-import FAQRouter from "./FAQRouter.jsx";
 import QNARouter from "./QNARouter.jsx";
-import CareGiverRouter from "./CareGiverRouter.jsx";
-import CareTakerRouter from "./CareTakerRouter.jsx";
+import MainPage from "../page/MainPage.jsx";
 
 const MainRouter = createBrowserRouter([
     {
         path: '/',
-        element: <AdminIndex/>,
-        children: [
-            QNARouter,
-            CareGiverRouter,
-        ]
+        element: <MainPage/>
     },
-    CareTakerRouter
+    QNARouter
 
 
     ]);

--- a/src/router/QNARouter.jsx
+++ b/src/router/QNARouter.jsx
@@ -1,9 +1,21 @@
 import {lazy} from "react";
 
+const QNAIndexBase = lazy(() => import('../page/QNAIndex'))
 const QNA = lazy(() => import('../page/QNAPage'))
+const ReadPage = lazy(() => import('../page/QNAReadPage'))
 
 const QnaRouter = {
     path: "/qna",
-    element: <QNA/>
+    element: <QNAIndexBase/>,
+    children: [
+        {
+          path: "",
+          element: <QNA/>
+        },
+        {
+            path:'read',
+            element: <ReadPage/>
+        }
+    ]
 }
 export default QnaRouter;


### PR DESCRIPTION
refactor: router edit

라우터 수정했는데, 우선 PR 하지말고 코드 설명후에 PR

기존의 라우터 방식으로 하면 MainRouter가 children으로 형성되어 QNARouter등 하위 라우터들이 childern을 이룰때 router를 적용하기 위해서 index와 outlet을 한번더 작성해야 하므로 위와같이 설계함.